### PR TITLE
fix: Add golangci-lint step to GitHub Actions CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
     - name: Run go vet
       run: go vet ./...
 
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+
     - name: Run unit tests
       run: go test -v -count=1 -race -coverprofile=coverage.txt ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       run: go vet ./...
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: v2.2.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: latest
+        version: v2.2.2
 
     - name: Run unit tests
       run: go test -v -count=1 -race -coverprofile=coverage.txt ./...


### PR DESCRIPTION
This pull request introduces a new step in the CI workflow to enhance code quality checks by integrating `golangci-lint`.

### CI Workflow Enhancements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR43-R47): Added a new step to run `golangci-lint` using the `golangci/golangci-lint-action@v6` action with the latest version. This ensures linting is performed as part of the CI pipeline.