### PR TITLE
fix: Update Makefile and CI configuration for user service context in…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     needs: test
     
     steps:
-    - name: Checkout user service
+    - name: Checkout code
       uses: actions/checkout@v4
 
     - name: Checkout system tests
@@ -86,6 +86,8 @@ jobs:
 
     - name: Start Full Infrastructure for Integration Tests
       working-directory: pinstack-system-tests
+      env:
+        USER_SERVICE_CONTEXT: ../
       run: |
         # Запускаем все необходимые контейнеры для интеграционных тестов
         docker compose -f docker-compose.test.yml up -d \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-unit: check-go-version
 start-user-infrastructure: setup-system-tests
 	@echo "🚀 Запуск полной инфраструктуры для интеграционных тестов..."
 	cd $(SYSTEM_TESTS_DIR) && \
-	docker compose -f docker-compose.test.yml up -d \
+	USER_SERVICE_CONTEXT=../pinstack-user-service docker compose -f docker-compose.test.yml up -d \
 		user-db-test \
 		user-migrator-test \
 		user-service-test \
@@ -131,6 +131,20 @@ logs-db:
 logs-auth-db:
 	cd $(SYSTEM_TESTS_DIR) && \
 	docker compose -f docker-compose.test.yml logs -f auth-db-test
+
+# Быстрый тест с локальным user-service
+quick-test-local: setup-system-tests
+	@echo "⚡ Быстрый запуск тестов с локальным user-service..."
+	cd $(SYSTEM_TESTS_DIR) && \
+	USER_SERVICE_CONTEXT=../pinstack-user-service docker compose -f docker-compose.test.yml up -d \
+		user-db-test user-migrator-test user-service-test \
+		auth-db-test auth-migrator-test auth-service-test \
+		api-gateway-test
+	@echo "⏳ Ожидание готовности сервисов..."
+	@sleep 30
+	cd $(SYSTEM_TESTS_DIR) && \
+	go test -v -count=1 -timeout=5m ./internal/scenarios/integration/gateway_user/...
+	$(MAKE) stop-user-infrastructure
 
 # Очистка
 clean: clean-user-infrastructure


### PR DESCRIPTION
This pull request updates the CI workflow and Makefile to improve integration test setup and add a new quick test command. The main changes focus on standardizing environment variable usage for Docker Compose commands and introducing a faster local test target.

**CI workflow improvements:**

* Renamed the step in `.github/workflows/ci.yml` from "Checkout user service" to "Checkout code" for clarity and consistency.
* Added the `USER_SERVICE_CONTEXT` environment variable to the "Start Full Infrastructure for Integration Tests" step to ensure the correct context is set for Docker Compose.

**Makefile enhancements:**

* Updated the `start-user-infrastructure` target to set the `USER_SERVICE_CONTEXT` environment variable when running Docker Compose, aligning local and CI environments.
* Added a new `quick-test-local` target for rapid integration testing with a local user service, including service startup, wait time, test execution, and cleanup.… integration tests