### PR TITLE
feat: Include password in user creation and update return values

### DIFF
--- a/internal/infrastructure/outbound/repository/postgres/repository.go
+++ b/internal/infrastructure/outbound/repository/postgres/repository.go
@@ -50,12 +50,13 @@ func (r *Repository) Create(ctx context.Context, user *models.User) (*models.Use
 	query := `
         INSERT INTO users (username, password, email, full_name, bio, avatar_url, created_at, updated_at)
         VALUES (@username, @password, @email, @full_name, @bio, @avatar_url, @created_at, @updated_at)
-        RETURNING id, username, email, full_name, bio, avatar_url, created_at, updated_at`
+        RETURNING id, username, password, email, full_name, bio, avatar_url, created_at, updated_at`
 
 	var createdUser models.User
 	err := r.pool.QueryRow(ctx, query, args).Scan(
 		&createdUser.ID,
 		&createdUser.Username,
+		&createdUser.Password,
 		&createdUser.Email,
 		&createdUser.FullName,
 		&createdUser.Bio,
@@ -259,12 +260,13 @@ func (r *Repository) Update(ctx context.Context, user *models.User) (*models.Use
 	}
 
 	query += ` WHERE id = @id 
-        RETURNING id, username, email, full_name, bio, avatar_url, created_at, updated_at`
+        RETURNING id, username, password, email, full_name, bio, avatar_url, created_at, updated_at`
 
 	var updatedUser models.User
 	err := r.pool.QueryRow(ctx, query, args).Scan(
 		&updatedUser.ID,
 		&updatedUser.Username,
+		&updatedUser.Password,
 		&updatedUser.Email,
 		&updatedUser.FullName,
 		&updatedUser.Bio,


### PR DESCRIPTION
This pull request updates the user creation and update logic in the Postgres repository to ensure the `password` field is included in both the returned columns and the scanned struct after an insert or update operation. This change helps maintain consistency and ensures the full user model, including the password, is available after these operations.

**Repository query and model updates:**

* Added the `password` field to the list of returned columns in both the `Create` and `Update` user queries in `repository.go`, ensuring the password is populated in the resulting `User` model. [[1]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL53-R59) [[2]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL262-R269)
* Updated the `Scan` calls to include the `Password` field, so the `User` struct returned from these methods contains the password value. [[1]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL53-R59) [[2]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL262-R269)