### PR TITLE
fix: Change Password field JSON tag to include it in the output

### DIFF
--- a/internal/domain/models/user.go
+++ b/internal/domain/models/user.go
@@ -6,7 +6,7 @@ type User struct {
 	ID        int64   `json:"id"`
 	Username  string  `json:"username"`
 	Email     string  `json:"email"`
-	Password  string  `json:"-"`
+	Password  string  `json:"password"`
 	FullName  *string `json:"full_name,omitempty"`
 	Bio       *string `json:"bio,omitempty"`
 	AvatarURL *string `json:"avatar_url,omitempty"`


### PR DESCRIPTION
This pull request makes a small change to the `User` struct in `internal/domain/models/user.go`, updating the way the `Password` field is handled in JSON serialization.

* The `Password` field is now included in JSON output (previously it was omitted), which may impact API responses and security considerations.