### PR TITLE
fix: Include Password field in user creation and update queries

### DIFF
--- a/internal/infrastructure/outbound/repository/postgres/repository.go
+++ b/internal/infrastructure/outbound/repository/postgres/repository.go
@@ -50,12 +50,13 @@ func (r *Repository) Create(ctx context.Context, user *models.User) (*models.Use
 	query := `
         INSERT INTO users (username, password, email, full_name, bio, avatar_url, created_at, updated_at)
         VALUES (@username, @password, @email, @full_name, @bio, @avatar_url, @created_at, @updated_at)
-        RETURNING id, username, email, full_name, bio, avatar_url, created_at, updated_at`
+        RETURNING id, username, password, email, full_name, bio, avatar_url, created_at, updated_at`
 
 	var createdUser models.User
 	err := r.pool.QueryRow(ctx, query, args).Scan(
 		&createdUser.ID,
 		&createdUser.Username,
+		&createdUser.Password,
 		&createdUser.Email,
 		&createdUser.FullName,
 		&createdUser.Bio,
@@ -259,12 +260,13 @@ func (r *Repository) Update(ctx context.Context, user *models.User) (*models.Use
 	}
 
 	query += ` WHERE id = @id 
-        RETURNING id, username, email, full_name, bio, avatar_url, created_at, updated_at`
+        RETURNING id, username, password, email, full_name, bio, avatar_url, created_at, updated_at`
 
 	var updatedUser models.User
 	err := r.pool.QueryRow(ctx, query, args).Scan(
 		&updatedUser.ID,
 		&updatedUser.Username,
+		&updatedUser.Password,
 		&updatedUser.Email,
 		&updatedUser.FullName,
 		&updatedUser.Bio,
@@ -352,7 +354,7 @@ func (r *Repository) Search(ctx context.Context, searchQuery string, offset, lim
 	}
 
 	query := `
-            SELECT id, username, email, full_name, bio, avatar_url, created_at, updated_at FROM users 
+            SELECT id, username, password, email, full_name, bio, avatar_url, created_at, updated_at FROM users 
             WHERE 
                 username ILIKE '%' || @query || '%' OR
                 email ILIKE '%' || @query || '%' OR
@@ -376,6 +378,7 @@ func (r *Repository) Search(ctx context.Context, searchQuery string, offset, lim
 		err := rows.Scan(
 			&user.ID,
 			&user.Username,
+			&user.Password,
 			&user.Email,
 			&user.FullName,
 			&user.Bio,


### PR DESCRIPTION
This pull request updates the user repository methods to consistently include the `password` field when creating, updating, and searching for users in the database. This change ensures that the `password` is always retrieved and available in the returned `User` model, which may be necessary for authentication or other logic.

Database query and model updates:

* Modified the `INSERT`, `UPDATE`, and `SELECT` queries in `repository.go` to include the `password` field in the returned columns, ensuring the `User` model is populated with the password after creation, update, and search operations. [[1]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL53-R59) [[2]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL262-R269) [[3]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL355-R357)
* Updated the `Scan` calls in the affected methods to correctly assign the `password` field to the `User` model. [[1]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL53-R59) [[2]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbL262-R269) [[3]](diffhunk://#diff-68a3e6ef41ab86f6268ccb6d454351dd74ef6fb06662477dd88cf603ff9e92dbR381)